### PR TITLE
Fixing problem with Pico DI

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/plugin/hibernate4/ConfigurationCreator.java
+++ b/src/main/java/br/com/caelum/vraptor/plugin/hibernate4/ConfigurationCreator.java
@@ -49,7 +49,7 @@ public class ConfigurationCreator
      * needs.
      */
     @PostConstruct
-    protected void create() {
+    public void create() {
         cfg = new Configuration().configure(env.getResource("/hibernate.cfg.xml"));
         configureExtras();
     }


### PR DESCRIPTION
When I was trying to inject a hibernate Session with Pico DI and vraptor-plugin-hibernate4 a IllegalAccessException was throw because the protected modifier.

I changed it to public, as requested by Lucas.

http://guj.com.br/java/279180-hibernate-4--vraptor
